### PR TITLE
feat: 添加提示词库功能

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,22 @@
 import React, { useEffect, useState, Suspense } from 'react';
 import { useAppStore } from './store/useAppStore';
+import { useUiStore } from './store/useUiStore';
 import { ChatInterface } from './components/ChatInterface';
 import { ToastContainer } from './components/ui/ToastContainer';
 import { GlobalDialog } from './components/ui/GlobalDialog';
 import { formatBalance } from './services/balanceService';
-import { Settings, Sun, Moon, Github, ImageIcon, DollarSign, Download } from 'lucide-react';
+import { Settings, Sun, Moon, Github, ImageIcon, DollarSign, Download, Sparkles } from 'lucide-react';
 import { lazyWithRetry, preloadComponents } from './utils/lazyLoadUtils';
 
 // Lazy load components
 const ApiKeyModal = lazyWithRetry(() => import('./components/ApiKeyModal').then(module => ({ default: module.ApiKeyModal })));
 const SettingsPanel = lazyWithRetry(() => import('./components/SettingsPanel').then(module => ({ default: module.SettingsPanel })));
 const ImageHistoryPanel = lazyWithRetry(() => import('./components/ImageHistoryPanel').then(module => ({ default: module.ImageHistoryPanel })));
+const PromptLibraryPanel = lazyWithRetry(() => import('./components/PromptLibraryPanel').then(module => ({ default: module.PromptLibraryPanel })));
 
 const App: React.FC = () => {
   const { apiKey, setApiKey, settings, updateSettings, isSettingsOpen, toggleSettings, imageHistory, balance, fetchBalance, installPrompt, setInstallPrompt } = useAppStore();
+  const { togglePromptLibrary, isPromptLibraryOpen } = useUiStore();
 
   useEffect(() => {
     const handleBeforeInstallPrompt = (e: Event) => {
@@ -55,6 +58,7 @@ const App: React.FC = () => {
       () => import('./components/ApiKeyModal'),
       () => import('./components/SettingsPanel'),
       () => import('./components/ImageHistoryPanel'),
+      () => import('./components/PromptLibraryPanel'),
       // Also preload components used in ChatInterface
       () => import('./components/ThinkingIndicator'),
       () => import('./components/MessageBubble'),
@@ -185,6 +189,17 @@ const App: React.FC = () => {
               )}
             </button>
             <button
+              onClick={togglePromptLibrary}
+              className={`rounded-lg p-2 transition focus:outline-none focus:ring-2 focus:ring-purple-500 ${
+                isPromptLibraryOpen
+                  ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400'
+                  : 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-white'
+              }`}
+              title="提示词库"
+            >
+              <Sparkles className="h-6 w-6" />
+            </button>
+            <button
               onClick={() => updateSettings({ theme: settings.theme === 'dark' ? 'light' : 'dark' })}
               className="rounded-lg p-2 text-gray-500 dark:text-gray-400 transition hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
               title="切换主题"
@@ -260,6 +275,7 @@ const App: React.FC = () => {
         {isImageHistoryOpen && (
           <ImageHistoryPanel isOpen={isImageHistoryOpen} onClose={() => setIsImageHistoryOpen(false)} />
         )}
+        <PromptLibraryPanel />
       </Suspense>
       <ToastContainer />
       <GlobalDialog />

--- a/src/components/InputArea.tsx
+++ b/src/components/InputArea.tsx
@@ -146,7 +146,7 @@ export const InputArea: React.FC<Props> = ({ onSend, onStop, onOpenArcade, isArc
     setInputText(value);
 
     // 检测 /t 触发（结尾是 /t 或 /t 后面跟着空格）
-    if (value.endsWith('/t') || value.match(/\/t\s/)) {
+    if (value.endsWith('/t') || value.match(/\/t\s*$/)) {
       setIsQuickPickerOpen(true);
     }
   };
@@ -154,7 +154,7 @@ export const InputArea: React.FC<Props> = ({ onSend, onStop, onOpenArcade, isArc
   // 处理快速选择器选择
   const handleQuickPickerSelect = (prompt: string) => {
     // 替换 /t 为实际提示词
-    const newText = inputText.replace(/\/t\s*$/, prompt);
+    const newText = inputText.replace(/\/t\s*/g, prompt);
     setInputText(newText);
     setIsQuickPickerOpen(false);
 

--- a/src/components/PromptLibraryPanel.tsx
+++ b/src/components/PromptLibraryPanel.tsx
@@ -149,7 +149,7 @@ export const PromptLibraryPanel: React.FC<PromptLibraryPanelProps> = ({ onSelect
             <div className="grid gap-4 grid-cols-1">
               {filteredPrompts.map((prompt, index) => (
                 <PromptCard
-                  key={index}
+                  key={`${prompt.title}-${prompt.author ?? index}`}
                   prompt={prompt}
                   onSelect={handleSelectPrompt}
                 />

--- a/src/components/PromptLibraryPanel.tsx
+++ b/src/components/PromptLibraryPanel.tsx
@@ -1,0 +1,268 @@
+import React, { useState, useEffect } from 'react';
+import { X, RefreshCw, Sparkles, ExternalLink, Loader2 } from 'lucide-react';
+import { useUiStore } from '../store/useUiStore';
+import { useAppStore } from '../store/useAppStore';
+import { PromptItem } from '../types';
+import { fetchPrompts, getCategories } from '../services/promptService';
+
+interface PromptLibraryPanelProps {
+  onSelectPrompt?: (prompt: string) => void;
+}
+
+export const PromptLibraryPanel: React.FC<PromptLibraryPanelProps> = ({ onSelectPrompt }) => {
+  const { isPromptLibraryOpen, closePromptLibrary, addToast } = useUiStore();
+  const { setInputText, inputText } = useAppStore();
+
+  const [prompts, setPrompts] = useState<PromptItem[]>([]);
+  const [filteredPrompts, setFilteredPrompts] = useState<PromptItem[]>([]);
+  const [categories, setCategories] = useState<string[]>(['全部']);
+  const [selectedCategory, setSelectedCategory] = useState('全部');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // 加载提示词数据
+  const loadPrompts = async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const data = await fetchPrompts();
+      setPrompts(data);
+      setFilteredPrompts(data);
+      setCategories(getCategories(data));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '加载失败';
+      setError(message);
+      addToast(message, 'error');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 面板打开时加载数据
+  useEffect(() => {
+    if (isPromptLibraryOpen && prompts.length === 0) {
+      loadPrompts();
+    }
+  }, [isPromptLibraryOpen]);
+
+  // 分类筛选
+  useEffect(() => {
+    if (selectedCategory === '全部') {
+      setFilteredPrompts(prompts);
+    } else {
+      setFilteredPrompts(prompts.filter(p => p.category === selectedCategory));
+    }
+  }, [selectedCategory, prompts]);
+
+  // 选择提示词
+  const handleSelectPrompt = (prompt: PromptItem) => {
+    if (onSelectPrompt) {
+      onSelectPrompt(prompt.prompt);
+    } else {
+      // 默认行为：追加到输入框
+      const newText = inputText ? `${inputText}\n\n${prompt.prompt}` : prompt.prompt;
+      setInputText(newText);
+    }
+
+    addToast(`已应用提示词：${prompt.title}`, 'success');
+    closePromptLibrary();
+  };
+
+  if (!isPromptLibraryOpen) return null;
+
+  return (
+    <>
+      {/* 遮罩层 */}
+      <div
+        className="fixed inset-0 z-40 bg-black/30 backdrop-blur-sm transition-opacity duration-300"
+        onClick={closePromptLibrary}
+      />
+
+      {/* 面板主体 */}
+      <div className="fixed right-0 top-0 z-50 h-full w-full sm:w-[600px] bg-white dark:bg-gray-900 shadow-2xl transform transition-transform duration-300 ease-out overflow-hidden flex flex-col">
+
+        {/* 头部 */}
+        <div className="flex items-center justify-between border-b border-gray-200 dark:border-gray-800 bg-gradient-to-r from-purple-50 to-blue-50 dark:from-gray-800 dark:to-gray-900 px-6 py-4">
+          <div className="flex items-center gap-2">
+            <Sparkles className="h-6 w-6 text-purple-600 dark:text-purple-400" />
+            <h2 className="text-xl font-bold text-gray-900 dark:text-white">提示词库</h2>
+          </div>
+          <button
+            onClick={closePromptLibrary}
+            className="flex h-9 w-9 items-center justify-center rounded-lg text-gray-500 hover:bg-white/50 dark:hover:bg-gray-800/50 hover:text-gray-900 dark:hover:text-white transition"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* 分类筛选 */}
+        <div className="border-b border-gray-200 dark:border-gray-800 px-6 py-3 bg-gray-50 dark:bg-gray-800/50">
+          <div className="flex gap-2 overflow-x-auto scrollbar-hide">
+            {categories.map(cat => (
+              <button
+                key={cat}
+                onClick={() => setSelectedCategory(cat)}
+                className={`px-4 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition ${
+                  selectedCategory === cat
+                    ? 'bg-purple-600 text-white shadow-lg shadow-purple-600/20'
+                    : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600'
+                }`}
+              >
+                {cat}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 内容区 */}
+        <div className="flex-1 overflow-y-auto px-6 py-4">
+          {isLoading ? (
+            // 加载状态
+            <div className="flex flex-col items-center justify-center h-full gap-3">
+              <Loader2 className="h-10 w-10 text-purple-600 dark:text-purple-400 animate-spin" />
+              <p className="text-sm text-gray-500 dark:text-gray-400">加载提示词中...</p>
+            </div>
+          ) : error ? (
+            // 错误状态
+            <div className="flex flex-col items-center justify-center h-full gap-4">
+              <div className="text-center">
+                <p className="text-red-600 dark:text-red-400 font-medium mb-2">加载失败</p>
+                <p className="text-sm text-gray-500 dark:text-gray-400">{error}</p>
+              </div>
+              <button
+                onClick={loadPrompts}
+                className="flex items-center gap-2 px-4 py-2 rounded-lg bg-purple-600 text-white hover:bg-purple-700 transition"
+              >
+                <RefreshCw className="h-4 w-4" />
+                重试
+              </button>
+            </div>
+          ) : filteredPrompts.length === 0 ? (
+            // 空状态
+            <div className="flex flex-col items-center justify-center h-full gap-2">
+              <Sparkles className="h-12 w-12 text-gray-300 dark:text-gray-600" />
+              <p className="text-sm text-gray-500 dark:text-gray-400">该分类暂无提示词</p>
+            </div>
+          ) : (
+            // 提示词列表
+            <div className="grid gap-4 grid-cols-1">
+              {filteredPrompts.map((prompt, index) => (
+                <PromptCard
+                  key={index}
+                  prompt={prompt}
+                  onSelect={handleSelectPrompt}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* 底部说明 */}
+        <div className="border-t border-gray-200 dark:border-gray-800 px-6 py-3 bg-gray-50 dark:bg-gray-800/50">
+          <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
+            提示词来源：
+            <a
+              href="https://github.com/glidea/banana-prompt-quicker"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-purple-600 dark:text-purple-400 hover:underline ml-1"
+            >
+              banana-prompt-quicker
+            </a>
+          </p>
+        </div>
+      </div>
+    </>
+  );
+};
+
+// 提示词卡片组件
+interface PromptCardProps {
+  prompt: PromptItem;
+  onSelect: (prompt: PromptItem) => void;
+}
+
+const PromptCard: React.FC<PromptCardProps> = ({ prompt, onSelect }) => {
+  const [imageLoaded, setImageLoaded] = useState(false);
+  const [imageError, setImageError] = useState(false);
+
+  return (
+    <div
+      onClick={() => onSelect(prompt)}
+      className="group cursor-pointer rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:border-purple-400 dark:hover:border-purple-600 hover:shadow-lg transition-all duration-200 overflow-hidden"
+    >
+      {/* 预览图 */}
+      <div className="relative aspect-video bg-gray-100 dark:bg-gray-700 overflow-hidden">
+        {!imageError ? (
+          <>
+            {!imageLoaded && (
+              <div className="absolute inset-0 flex items-center justify-center">
+                <Loader2 className="h-6 w-6 text-gray-400 animate-spin" />
+              </div>
+            )}
+            <img
+              src={prompt.preview}
+              alt={prompt.title}
+              loading="lazy"
+              onLoad={() => setImageLoaded(true)}
+              onError={() => setImageError(true)}
+              className={`w-full h-full object-cover group-hover:scale-105 transition-transform duration-300 ${
+                imageLoaded ? 'opacity-100' : 'opacity-0'
+              }`}
+            />
+          </>
+        ) : (
+          <div className="absolute inset-0 flex items-center justify-center text-gray-400">
+            <Sparkles className="h-8 w-8" />
+          </div>
+        )}
+
+        {/* 分类标签 */}
+        <div className="absolute top-2 left-2">
+          <span className="px-2 py-1 rounded-md text-xs font-medium bg-black/60 text-white backdrop-blur-sm">
+            {prompt.category}
+          </span>
+        </div>
+
+        {/* 模式标签 */}
+        <div className="absolute top-2 right-2">
+          <span className="px-2 py-1 rounded-md text-xs font-medium bg-purple-600/90 text-white backdrop-blur-sm">
+            {prompt.mode === 'edit' ? '编辑' : '生成'}
+          </span>
+        </div>
+      </div>
+
+      {/* 内容区 */}
+      <div className="p-4">
+        <h3 className="font-semibold text-gray-900 dark:text-white mb-2 line-clamp-1">
+          {prompt.title}
+        </h3>
+
+        <p className="text-sm text-gray-600 dark:text-gray-400 line-clamp-2 mb-3">
+          {prompt.prompt}
+        </p>
+
+        <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+          <span className="flex items-center gap-1">
+            <span>作者：</span>
+            <span className="font-medium">{prompt.author}</span>
+          </span>
+
+          {prompt.link && (
+            <a
+              href={prompt.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              className="flex items-center gap-1 text-purple-600 dark:text-purple-400 hover:underline"
+            >
+              查看详情
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/PromptQuickPicker.tsx
+++ b/src/components/PromptQuickPicker.tsx
@@ -1,0 +1,373 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Search, Sparkles, X, ArrowUp, ArrowDown, ExternalLink } from 'lucide-react';
+import { PromptItem } from '../types';
+import { fetchPrompts, getCategories } from '../services/promptService';
+
+interface PromptQuickPickerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (prompt: string) => void;
+  searchQuery?: string;
+}
+
+export const PromptQuickPicker: React.FC<PromptQuickPickerProps> = ({
+  isOpen,
+  onClose,
+  onSelect,
+  searchQuery = '',
+}) => {
+  const [prompts, setPrompts] = useState<PromptItem[]>([]);
+  const [filteredPrompts, setFilteredPrompts] = useState<PromptItem[]>([]);
+  const [categories, setCategories] = useState<string[]>(['全部']);
+  const [selectedCategory, setSelectedCategory] = useState('全部');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [hoveredPrompt, setHoveredPrompt] = useState<PromptItem | null>(null);
+  const [search, setSearch] = useState(searchQuery);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // 加载提示词数据
+  useEffect(() => {
+    if (isOpen && prompts.length === 0) {
+      loadPrompts();
+    }
+  }, [isOpen]);
+
+  // 聚焦搜索框
+  useEffect(() => {
+    if (isOpen && searchInputRef.current) {
+      setTimeout(() => searchInputRef.current?.focus(), 100);
+    }
+  }, [isOpen]);
+
+  // 过滤提示词（支持分类和搜索）
+  useEffect(() => {
+    let filtered = prompts;
+
+    // 先按分类筛选
+    if (selectedCategory !== '全部') {
+      filtered = filtered.filter(p => p.category === selectedCategory);
+    }
+
+    // 再按搜索词筛选
+    if (search.trim()) {
+      const query = search.toLowerCase();
+      filtered = filtered.filter(
+        p =>
+          p.title.toLowerCase().includes(query) ||
+          p.prompt.toLowerCase().includes(query) ||
+          p.category.toLowerCase().includes(query) ||
+          p.author.toLowerCase().includes(query)
+      );
+    }
+
+    setFilteredPrompts(filtered);
+    setSelectedIndex(0);
+  }, [search, prompts, selectedCategory]);
+
+  // 滚动到选中项
+  useEffect(() => {
+    if (listRef.current) {
+      const selectedElement = listRef.current.children[selectedIndex] as HTMLElement;
+      if (selectedElement) {
+        selectedElement.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      }
+    }
+  }, [selectedIndex]);
+
+  // 自动设置预览为当前选中项
+  useEffect(() => {
+    if (filteredPrompts[selectedIndex] && !hoveredPrompt) {
+      setHoveredPrompt(filteredPrompts[selectedIndex]);
+    }
+  }, [selectedIndex, filteredPrompts]);
+
+  const loadPrompts = async () => {
+    setIsLoading(true);
+    try {
+      const data = await fetchPrompts();
+      setPrompts(data);
+      setFilteredPrompts(data);
+      setCategories(getCategories(data));
+    } catch (error) {
+      console.error('Failed to load prompts:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 键盘导航
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setSelectedIndex(prev => Math.min(prev + 1, filteredPrompts.length - 1));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setSelectedIndex(prev => Math.max(prev - 1, 0));
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (filteredPrompts[selectedIndex]) {
+          handleSelect(filteredPrompts[selectedIndex]);
+        }
+        break;
+      case 'Escape':
+        e.preventDefault();
+        onClose();
+        break;
+    }
+  };
+
+  const handleSelect = (prompt: PromptItem) => {
+    onSelect(prompt.prompt);
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* 遮罩层 */}
+      <div
+        className="fixed inset-0 z-40 bg-black/20"
+        onClick={onClose}
+      />
+
+      {/* 快速选择器 */}
+      <div className="fixed inset-x-4 top-1/2 -translate-y-1/2 z-50 mx-auto max-w-6xl">
+        <div className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-2xl overflow-hidden">
+
+          {/* 搜索框 */}
+          <div className="flex items-center gap-2 border-b border-gray-200 dark:border-gray-700 px-4 py-3 bg-gradient-to-r from-purple-50 to-blue-50 dark:from-gray-800 dark:to-gray-900">
+            <Search className="h-5 w-5 text-purple-600 dark:text-purple-400 shrink-0" />
+            <input
+              ref={searchInputRef}
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="搜索提示词..."
+              className="flex-1 bg-transparent text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none text-sm"
+            />
+            <button
+              onClick={onClose}
+              className="shrink-0 p-1 rounded-lg text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-white/50 dark:hover:bg-gray-700/50 transition"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+
+          {/* 分类筛选 */}
+          <div className="border-b border-gray-200 dark:border-gray-700 px-4 py-2 bg-gray-50 dark:bg-gray-800/50">
+            <div className="flex gap-2 overflow-x-auto scrollbar-hide">
+              {categories.map(cat => (
+                <button
+                  key={cat}
+                  onClick={() => setSelectedCategory(cat)}
+                  className={`px-3 py-1 rounded-full text-xs font-medium whitespace-nowrap transition ${
+                    selectedCategory === cat
+                      ? 'bg-purple-600 text-white shadow-lg shadow-purple-600/20'
+                      : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600'
+                  }`}
+                >
+                  {cat}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* 主体区域：左右布局 */}
+          <div className="flex h-[500px]">
+            {/* 左侧：提示词列表 */}
+            <div className="flex-1 border-r border-gray-200 dark:border-gray-700 overflow-hidden flex flex-col">
+              <div
+                ref={listRef}
+                className="flex-1 overflow-y-auto overscroll-contain"
+                onKeyDown={handleKeyDown}
+              >
+                {isLoading ? (
+                  <div className="flex items-center justify-center py-12 text-gray-500 dark:text-gray-400">
+                    <div className="flex flex-col items-center gap-2">
+                      <Sparkles className="h-6 w-6 animate-pulse" />
+                      <span className="text-sm">加载中...</span>
+                    </div>
+                  </div>
+                ) : filteredPrompts.length === 0 ? (
+                  <div className="flex items-center justify-center py-12 text-gray-500 dark:text-gray-400">
+                    <div className="flex flex-col items-center gap-2">
+                      <Search className="h-6 w-6" />
+                      <span className="text-sm">未找到匹配的提示词</span>
+                    </div>
+                  </div>
+                ) : (
+                  filteredPrompts.map((prompt, index) => (
+                    <div
+                      key={index}
+                      onClick={() => handleSelect(prompt)}
+                      onMouseEnter={() => setHoveredPrompt(prompt)}
+                      className={`px-4 py-3 cursor-pointer transition border-b border-gray-100 dark:border-gray-700/50 last:border-0 ${
+                        index === selectedIndex
+                          ? 'bg-purple-50 dark:bg-purple-900/20'
+                          : 'hover:bg-gray-50 dark:hover:bg-gray-700/50'
+                      }`}
+                    >
+                      <div className="flex items-start gap-3">
+                        {/* 序号 */}
+                        <div className={`shrink-0 w-6 h-6 rounded-md flex items-center justify-center text-xs font-medium ${
+                          index === selectedIndex
+                            ? 'bg-purple-600 text-white'
+                            : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
+                        }`}>
+                          {index + 1}
+                        </div>
+
+                        {/* 内容 */}
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2 mb-1">
+                            <h3 className="font-medium text-gray-900 dark:text-white text-sm truncate">
+                              {prompt.title}
+                            </h3>
+                            <span className="shrink-0 px-2 py-0.5 rounded-md text-xs font-medium bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400">
+                              {prompt.category}
+                            </span>
+                          </div>
+                          <p className="text-xs text-gray-600 dark:text-gray-400 line-clamp-1">
+                            {prompt.prompt}
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+
+              {/* 左侧底部提示 */}
+              <div className="border-t border-gray-200 dark:border-gray-700 px-4 py-2 bg-gray-50 dark:bg-gray-800/50">
+                <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+                  <div className="flex items-center gap-4">
+                    <span className="flex items-center gap-1">
+                      <kbd className="px-1.5 py-0.5 rounded bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 font-mono">↑↓</kbd>
+                      导航
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <kbd className="px-1.5 py-0.5 rounded bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 font-mono">Enter</kbd>
+                      选择
+                    </span>
+                  </div>
+                  <span>{filteredPrompts.length} 个结果</span>
+                </div>
+              </div>
+            </div>
+
+            {/* 右侧：详情预览 */}
+            <div className="w-80 bg-gray-50 dark:bg-gray-900 overflow-y-auto">
+              {hoveredPrompt ? (
+                <PromptDetailPreview prompt={hoveredPrompt} />
+              ) : (
+                <div className="flex items-center justify-center h-full text-gray-400 dark:text-gray-600">
+                  <div className="text-center">
+                    <Sparkles className="h-12 w-12 mx-auto mb-2 opacity-50" />
+                    <p className="text-sm">悬停查看详情</p>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+// 提示词详情预览组件
+interface PromptDetailPreviewProps {
+  prompt: PromptItem;
+}
+
+const PromptDetailPreview: React.FC<PromptDetailPreviewProps> = ({ prompt }) => {
+  const [imageLoaded, setImageLoaded] = useState(false);
+  const [imageError, setImageError] = useState(false);
+
+  return (
+    <div className="p-4 space-y-4">
+      {/* 预览图 */}
+      <div className="relative aspect-video bg-gray-200 dark:bg-gray-800 rounded-lg overflow-hidden">
+        {!imageError ? (
+          <>
+            {!imageLoaded && (
+              <div className="absolute inset-0 flex items-center justify-center">
+                <Sparkles className="h-8 w-8 text-gray-400 animate-pulse" />
+              </div>
+            )}
+            <img
+              src={prompt.preview}
+              alt={prompt.title}
+              loading="lazy"
+              onLoad={() => setImageLoaded(true)}
+              onError={() => setImageError(true)}
+              className={`w-full h-full object-cover transition-opacity duration-300 ${
+                imageLoaded ? 'opacity-100' : 'opacity-0'
+              }`}
+            />
+          </>
+        ) : (
+          <div className="absolute inset-0 flex items-center justify-center text-gray-400">
+            <Sparkles className="h-12 w-12" />
+          </div>
+        )}
+      </div>
+
+      {/* 标题和标签 */}
+      <div>
+        <h3 className="font-bold text-gray-900 dark:text-white mb-2">
+          {prompt.title}
+        </h3>
+        <div className="flex items-center gap-2">
+          <span className="px-2 py-1 rounded-md text-xs font-medium bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400">
+            {prompt.category}
+          </span>
+          <span className="px-2 py-1 rounded-md text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400">
+            {prompt.mode === 'edit' ? '编辑' : '生成'}
+          </span>
+        </div>
+      </div>
+
+      {/* 提示词内容 */}
+      <div>
+        <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
+          提示词内容
+        </div>
+        <div className="text-sm text-gray-900 dark:text-white bg-white dark:bg-gray-800 rounded-lg p-3 border border-gray-200 dark:border-gray-700 max-h-48 overflow-y-auto">
+          {prompt.prompt}
+        </div>
+      </div>
+
+      {/* 作者信息 */}
+      <div>
+        <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
+          作者
+        </div>
+        <div className="text-sm text-gray-700 dark:text-gray-300">
+          {prompt.author}
+        </div>
+      </div>
+
+      {/* 查看详情链接 */}
+      {prompt.link && (
+        <a
+          href={prompt.link}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center justify-center gap-2 w-full py-2 px-4 rounded-lg bg-purple-600 hover:bg-purple-700 text-white text-sm font-medium transition"
+        >
+          <ExternalLink className="h-4 w-4" />
+          查看详情
+        </a>
+      )}
+    </div>
+  );
+};

--- a/src/components/PromptQuickPicker.tsx
+++ b/src/components/PromptQuickPicker.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Search, Sparkles, X, ArrowUp, ArrowDown, ExternalLink } from 'lucide-react';
+import { Search, Sparkles, X, ExternalLink } from 'lucide-react';
 import { PromptItem } from '../types';
 import { fetchPrompts, getCategories } from '../services/promptService';
 
@@ -135,10 +135,15 @@ export const PromptQuickPicker: React.FC<PromptQuickPickerProps> = ({
       <div
         className="fixed inset-0 z-40 bg-black/20"
         onClick={onClose}
+        tabIndex={-1}
       />
 
       {/* 快速选择器 */}
-      <div className="fixed inset-x-4 top-1/2 -translate-y-1/2 z-50 mx-auto max-w-6xl">
+      <div
+        className="fixed inset-x-4 top-1/2 -translate-y-1/2 z-50 mx-auto max-w-6xl"
+        role="dialog"
+        aria-modal="true"
+      >
         <div className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-2xl overflow-hidden">
 
           {/* 搜索框 */}
@@ -206,7 +211,7 @@ export const PromptQuickPicker: React.FC<PromptQuickPickerProps> = ({
                 ) : (
                   filteredPrompts.map((prompt, index) => (
                     <div
-                      key={index}
+                      key={`${prompt.title}-${prompt.category}`}
                       onClick={() => handleSelect(prompt)}
                       onMouseEnter={() => setHoveredPrompt(prompt)}
                       className={`px-4 py-3 cursor-pointer transition border-b border-gray-100 dark:border-gray-700/50 last:border-0 ${

--- a/src/services/promptService.ts
+++ b/src/services/promptService.ts
@@ -130,7 +130,7 @@ function isValidPromptItem(item: any): item is PromptItem {
  */
 export function getCategories(prompts: PromptItem[]): string[] {
   const categories = new Set<string>();
-  prompts.forEach(p => categories.add(p.category));
+  prompts.forEach(p => { categories.add(p.category); });
   return ['全部', ...Array.from(categories).sort()];
 }
 

--- a/src/services/promptService.ts
+++ b/src/services/promptService.ts
@@ -1,0 +1,146 @@
+import { PromptItem } from '../types';
+
+const PROMPT_API_URL = 'https://raw.githubusercontent.com/glidea/banana-prompt-quicker/main/prompts.json';
+const CACHE_KEY = 'prompt_library_cache';
+const CACHE_DURATION = 24 * 60 * 60 * 1000; // 24小时
+
+interface CachedData {
+  prompts: PromptItem[];
+  timestamp: number;
+}
+
+/**
+ * 从缓存或 API 获取提示词数据
+ */
+export async function fetchPrompts(): Promise<PromptItem[]> {
+  try {
+    // 尝试从缓存读取
+    const cached = getCachedPrompts();
+    if (cached) {
+      return cached;
+    }
+
+    // 缓存过期或不存在,从 API 获取
+    const response = await fetch(PROMPT_API_URL);
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    // 验证数据格式
+    if (!Array.isArray(data)) {
+      throw new Error('Invalid data format: expected array');
+    }
+
+    // 过滤并验证每个提示词项
+    const validPrompts: PromptItem[] = data.filter(isValidPromptItem);
+
+    // 缓存数据
+    cachePrompts(validPrompts);
+
+    return validPrompts;
+  } catch (error) {
+    console.error('Failed to fetch prompts:', error);
+
+    // 如果网络请求失败,尝试返回过期的缓存数据
+    const staleCache = getStaleCache();
+    if (staleCache) {
+      return staleCache;
+    }
+
+    throw new Error('无法获取提示词数据,请检查网络连接后重试');
+  }
+}
+
+/**
+ * 从缓存读取提示词(仅返回未过期的数据)
+ */
+function getCachedPrompts(): PromptItem[] | null {
+  try {
+    const cached = localStorage.getItem(CACHE_KEY);
+    if (!cached) return null;
+
+    const data: CachedData = JSON.parse(cached);
+    const now = Date.now();
+
+    // 检查缓存是否过期
+    if (now - data.timestamp > CACHE_DURATION) {
+      return null;
+    }
+
+    return data.prompts;
+  } catch (error) {
+    console.error('Failed to read cache:', error);
+    return null;
+  }
+}
+
+/**
+ * 获取过期的缓存数据(网络请求失败时的备选方案)
+ */
+function getStaleCache(): PromptItem[] | null {
+  try {
+    const cached = localStorage.getItem(CACHE_KEY);
+    if (!cached) return null;
+
+    const data: CachedData = JSON.parse(cached);
+    return data.prompts;
+  } catch (error) {
+    return null;
+  }
+}
+
+/**
+ * 缓存提示词数据
+ */
+function cachePrompts(prompts: PromptItem[]): void {
+  try {
+    const data: CachedData = {
+      prompts,
+      timestamp: Date.now(),
+    };
+    localStorage.setItem(CACHE_KEY, JSON.stringify(data));
+  } catch (error) {
+    console.error('Failed to cache prompts:', error);
+    // 缓存失败不影响主流程,静默失败
+  }
+}
+
+/**
+ * 验证提示词项是否有效
+ */
+function isValidPromptItem(item: any): item is PromptItem {
+  return (
+    item &&
+    typeof item === 'object' &&
+    typeof item.title === 'string' &&
+    typeof item.preview === 'string' &&
+    typeof item.prompt === 'string' &&
+    typeof item.author === 'string' &&
+    typeof item.link === 'string' &&
+    (item.mode === 'edit' || item.mode === 'generate') &&
+    typeof item.category === 'string'
+  );
+}
+
+/**
+ * 获取所有唯一的分类
+ */
+export function getCategories(prompts: PromptItem[]): string[] {
+  const categories = new Set<string>();
+  prompts.forEach(p => categories.add(p.category));
+  return ['全部', ...Array.from(categories).sort()];
+}
+
+/**
+ * 清除缓存
+ */
+export function clearPromptsCache(): void {
+  try {
+    localStorage.removeItem(CACHE_KEY);
+  } catch (error) {
+    console.error('Failed to clear cache:', error);
+  }
+}

--- a/src/store/useUiStore.ts
+++ b/src/store/useUiStore.ts
@@ -20,23 +20,27 @@ export interface DialogOptions {
 interface UiState {
   toasts: Toast[];
   dialog: DialogOptions | null;
-  
+  isPromptLibraryOpen: boolean;
+
   addToast: (message: string, type?: ToastType) => void;
   removeToast: (id: string) => void;
   showDialog: (options: DialogOptions) => void;
   closeDialog: () => void;
+  togglePromptLibrary: () => void;
+  closePromptLibrary: () => void;
 }
 
 export const useUiStore = create<UiState>((set) => ({
   toasts: [],
   dialog: null,
+  isPromptLibraryOpen: false,
 
   addToast: (message, type = 'info') => {
     const id = Date.now().toString();
     set((state) => ({
       toasts: [...state.toasts, { id, message, type }]
     }));
-    
+
     // Auto remove after 3 seconds
     setTimeout(() => {
       set((state) => ({
@@ -51,6 +55,11 @@ export const useUiStore = create<UiState>((set) => ({
     })),
 
   showDialog: (options) => set({ dialog: options }),
-  
+
   closeDialog: () => set({ dialog: null }),
+
+  togglePromptLibrary: () =>
+    set((state) => ({ isPromptLibraryOpen: !state.isPromptLibraryOpen })),
+
+  closePromptLibrary: () => set({ isPromptLibraryOpen: false }),
 }));

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,3 +49,13 @@ export interface ImageHistoryItem {
   timestamp: number;
   modelName?: string;
 }
+
+export interface PromptItem {
+  title: string;
+  preview: string;
+  prompt: string;
+  author: string;
+  link: string;
+  mode: 'edit' | 'generate';
+  category: string;
+}


### PR DESCRIPTION
功能特性：
- 提示词库面板：展示所有提示词，支持分类筛选和搜索
- 快速选择器：输入 /t 快捷键快速选择提示词
- 双重入口：顶部导航栏和输入框均可打开
- 详情预览：悬停查看提示词详情、预览图、作者信息
- 分类筛选：支持按分类快速筛选提示词
- 性能优化：24小时本地缓存，懒加载组件

新增文件：
- src/components/PromptLibraryPanel.tsx - 提示词库侧边面板
- src/components/PromptQuickPicker.tsx - 快速选择器弹窗
- src/services/promptService.ts - 提示词数据服务

修改文件：
- src/App.tsx - 添加顶部提示词库按钮
- src/components/InputArea.tsx - 添加输入框提示词按钮和 /t 触发器
- src/store/useUiStore.ts - 添加提示词库面板状态管理
- src/types.ts - 添加 PromptItem 类型定义

数据来源：https://github.com/glidea/banana-prompt-quicker